### PR TITLE
docs(aivss): add scenario-based scoring walkthrough for prompt injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ AISpecificMetrics = [MR × DS × EI × DC × AD × AA × LL × GV × CS] × Mode
 *   **CS (Cloud Security Alliance LLM Taxonomy):**  Addresses specific threats to LLMs in cloud environments, as defined by the CSA LLM Threat Taxonomy.
 *   **ModelComplexityMultiplier:** A factor that adjusts the AI-Specific Metrics score based on the complexity of the AI model (ranging from 1.0 for simple models to 1.5 for highly complex models).
 
+    ## Example: Scoring an AI Vulnerability with AIVSS
+
+This section illustrates how AIVSS can be used to reason about risk in a practical AI security scenario.
+
+### Scenario
+A customer support chatbot powered by a Large Language Model (LLM) is exposed to untrusted user input. Through prompt injection, an attacker can influence the system to ignore intended constraints, resulting in the disclosure of internal instructions or the generation of unauthorized responses.
+
+### Key Risk Considerations
+- **Attack Vector**: The issue is exploitable remotely through standard user interaction.
+- **Attack Complexity**: Low. No privileged access or specialized tooling is required.
+- **Failure Visibility**: Low. Harmful or incorrect outputs may appear legitimate to end users.
+- **Potential Impact**: High. Outcomes may include sensitive information disclosure or policy-violating responses.
+- **Risk Persistence**: Medium to High. The behavior may repeat until mitigations such as prompt hardening, input handling, or monitoring are applied.
+
+### Limitations of Traditional Scoring
+In this scenario, the system continues operating as designed while producing unsafe outcomes. Traditional vulnerability scoring models emphasize software faults and observable failures, which can lead to underestimating risks that manifest as subtle or behavioral issues.
+
+### Value of AIVSS
+AIVSS is designed to capture AI-specific risk factors, including behavioral manipulation, limited observability, and the potential for risk to evolve over time. By accounting for these characteristics, AIVSS enables more accurate prioritization of vulnerabilities that may otherwise appear low severity using conventional approaches.
+
+This example highlights how AIVSS helps surface and contextualize risks that are unique to AI-driven systems.
+
 ### 3.3. Environmental Metrics ###
 
 Environmental Metrics reflect the characteristics of the AI system's deployment environment that can influence the overall risk.
@@ -895,3 +917,4 @@ The AIVSS framework provides a structured and comprehensive approach to assessin
 **Disclaimer:**
 
 AIVSS is a framework for assessing and scoring the security risks of AI systems. It is not a guarantee of security, and it should not be used as the sole basis for making security decisions. Organizations should use AIVSS in conjunction with other security best practices and should always exercise their own judgment when assessing and mitigating AI security risks.
+


### PR DESCRIPTION
Adds a practical, scenario-based example demonstrating how AIVSS applies to a common LLM prompt-injection vulnerability, helping bridge framework concepts with real-world usage.