### PR TITLE
Update Implementation_Details.md to document V3 calculator

### DIFF
--- a/Implementation_Details.md
+++ b/Implementation_Details.md
@@ -5,7 +5,7 @@ The user can easily assess different vulnerabilities by providing inputs through
 <img width="759" alt="Screenshot 2024-12-18 at 3 08 15 PM" src="https://github.com/user-attachments/assets/25870bd2-1f25-4b22-a26b-4cfc3a09b603" />
 
 ### Instructions
-- Run the Python file from your terminal using python aivss_calculatorV1/V2.py
+- Run the Python file from your terminal using `python aivss_calculatorV3.py` (recommended) or `aivss_calculatorV1/V2.py`
 - Provide the appropriate values for each parameter being assessed
 - This will print the calculated AIVSS score to the console.
 
@@ -20,3 +20,14 @@ Key changes:
 - New parameter value dictionaries: Dictionaries for the new AI-specific metrics (MR, DS, EI, DC, AD) have been added with their corresponding values and descriptions.
 - Updated weights: The weights assigned to the base metrics (w1), AI-specific metrics (w2), and impact metrics (w3) have been updated to 0.25, 0.45, and 0.30, respectively, as per the new scoring methodology.
 - Interactive input for all parameters: The code now prompts the user to select values for all parameters, including the AI-specific metrics, using the get_user_input function.
+
+### V3 Updates
+Full spec-compliant implementation. Key changes (addresses issue #15):
+- All 9 AI-specific metrics implemented: adds AA (Adversarial Attack Surface), LL (Lifecycle Vulnerabilities), GV (Governance and Validation), and CS (Cloud/LLM-Specific Security) — V1/V2 only covered 5/9.
+- ModelComplexityMultiplier added (1.0–1.5) per spec Section 3.2.
+- Corrected weights to spec values: w1=0.3, w2=0.5, w3=0.2.
+- Temporal Metrics added: Exploitability (E), Remediation Level (RL), Report Confidence (RC).
+- Environmental Requirement Metrics added: CR, IR, AR, SIR.
+- MitigationMultiplier added (1.0–1.5).
+- "Safety Impact" label corrected to "Societal Impact" per spec.
+- Full score breakdown output showing each component and the formula applied.


### PR DESCRIPTION
## Summary

Follow-up to #25 — updates `Implementation_Details.md` to reflect the new `aivss_calculatorV3.py` added in that PR.

**Contributor:** BSec (Bhasker) — https://www.linkedin.com/in/bhaskerkpatel/

## Changes

- **Run instructions** updated to recommend `aivss_calculatorV3.py` as the primary calculator
- **V3 Updates section** added, documenting all changes over V1/V2:
  - All 9 AI-specific metrics now implemented (AA, LL, GV, CS were missing)
  - ModelComplexityMultiplier added
  - Corrected weights (w1=0.3, w2=0.5, w3=0.2 per spec)
  - Temporal and Environmental Metrics added
  - MitigationMultiplier added
  - "Safety Impact" label corrected to "Societal Impact"
  - Full score breakdown output

## Test plan

- [x] Verified the file renders correctly in Markdown
- [x] All version history (V1, V2, V3) is now consistently documented