### PR TITLE
Add deprecation warnings to aivss_calculatorV1 and V2

### DIFF
--- a/aivss_calculatorV1.py
+++ b/aivss_calculatorV1.py
@@ -1,3 +1,13 @@
+import warnings
+
+warnings.warn(
+    "aivss_calculatorV1.py is deprecated and implements only 5 of the 9 required "
+    "AI-specific metrics with incorrect weights. Use aivss_calculatorV3.py instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
 def calculate_aivss_score():
     """Calculates the AIVSS score interactively based on user input."""
 

--- a/aivss_calculatorV2.py
+++ b/aivss_calculatorV2.py
@@ -1,3 +1,13 @@
+import warnings
+
+warnings.warn(
+    "aivss_calculatorV2.py is deprecated and implements only 5 of the 9 required "
+    "AI-specific metrics with incorrect weights. Use aivss_calculatorV3.py instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
 def calculate_aivss_score():
     """Calculates the AIVSS score interactively based on user input and the updated scoring rubric."""
 


### PR DESCRIPTION
## Summary

Adds `DeprecationWarning` to `aivss_calculatorV1.py` and `aivss_calculatorV2.py` so users are immediately directed to the spec-compliant `aivss_calculatorV3.py`.

**Contributor:** BSec (Bhasker) — https://www.linkedin.com/in/bhaskerkpatel/

## Problem

Both V1 and V2 silently produce incorrect scores:
- Only 5 of 9 required AI-specific metrics are implemented (AA, LL, GV, CS missing)
- Weights do not match the spec (V1: 0.4/0.4/0.2, V2: 0.25/0.45/0.30 vs spec: 0.3/0.5/0.2)
- No Temporal Metrics, Environmental Metrics, or MitigationMultiplier

Users running these files have no indication that a correct implementation exists.

## Fix

Added a `warnings.warn(..., DeprecationWarning)` at the top of each file. When run, users will see:

```
DeprecationWarning: aivss_calculatorV1.py is deprecated and implements only 5 of the 9 required
AI-specific metrics with incorrect weights. Use aivss_calculatorV3.py instead.
```

## Test plan

- [x] Verified warning fires on import and direct execution
- [x] Existing calculator logic is unchanged