### PR TITLE
Add MCP-Tool-Capability-AIVSS.md: crosswalk from enforced tool posture to AIVSS inputs

### DIFF
--- a/MCP-Tool-Capability-AIVSS.md
+++ b/MCP-Tool-Capability-AIVSS.md
@@ -1,0 +1,174 @@
+---
+layout: col-sidebar
+title: "AIVSS Crosswalk for MCP Tool Capability"
+tags: aivss, mcp, agentic, tool-use, crosswalk
+type: documentation
+---
+
+# AIVSS Crosswalk for MCP Tool Capability #
+
+**Status:** Draft for v1.0 public review (framework-mapping contribution).
+**Scope:** A single tool, not an agent system. It maps a tool's enforced capability posture to existing AIVSS inputs.
+
+## Introduction ##
+
+AIVSS names **External Tool Control Surface** among its ten agentic amplification factors, recognizing that broad tool access multiplies the blast radius of any vulnerability. Scoring a single tool's control surface, however, is today a manual judgment. Reviewers interpret the same tool differently; the resulting score is hard to reproduce; "what privileges does this tool actually hold at runtime" is rarely written down.
+
+This document offers a crosswalk that removes that ambiguity for one well-defined case. When a tool runs inside a sandbox that **enforces** a declared capability posture (its network, filesystem, and process/class permissions), the posture becomes a reproducible AIVSS input. Two properties make it reproducible. First, the specification requires the runtime to be no more permissive than the policy, so the posture is meant as an upper bound the runtime enforces, not an estimate; the runtime obligations and scoring caveats that property depends on are listed in *Conformance requirements for the runtime*. Second, the policy is an inspectable on-disk artifact, so two reviewers reading it arrive at the same number.
+
+The mapping calibrates the External Tool Control Surface amplification factor and several CS, DC, and Impact metrics in the AIVSS scoring rubric (the AIVSS project README, Sections 4 and 6). A working reference implementation is described at the end of this document.
+
+### What this is, and what it is not ###
+
+* It is an input provider. It derives existing AIVSS factor values from an enforced, inspectable tool policy.
+* It is not a competing severity scale. AIVSS scores a vulnerability's severity; a capability posture measures a tool's blast radius. The posture is one reproducible input to the AIVSS score, never a replacement for it.
+
+> **One anchor, not two models.** The mapping below is anchored on the enforced sandbox posture of a locally-authored tool. That is the part of the reference implementation that is both a normative specification and enforced at runtime, subject to the conformance requirements below. A separate, lower-assurance signal for external and untrusted tools (declared MCP annotations plus a change-detection ledger) is mapped afterward, in the *External Tools* section. The two are scored by independent models that never mix.
+
+## Why a reproducible tool-capability input ##
+
+The decisive question for agentic tool use is not only whether the model can be manipulated. It is what the tool the model calls can actually do. Two tools behind the same LLM can have very different blast radii. A pure-compute formatter cannot reach the network or the disk. A shell-exec tool can change the scope of the entire host. Today that difference is captured, if at all, in a reviewer's prose, with three costs: interpretation varies between reviewers, the score is not reproducible, and a tool's true runtime privileges often go undocumented. An enforced posture removes all three. It is:
+
+* **Reproducible.** It is derived from a declared, enforced policy, not from a reviewer's reading.
+* **Conservative.** The specification bounds the runtime to no more than the declared posture, so the input is an upper bound on capability (subject to the runtime conformance requirements below).
+* **Inspectable.** The policy is an on-disk artifact, and the specification defines an audit contract under which the resolved posture is recorded per invocation.
+
+## The enforced capability model (L0–L5) ##
+
+A reference resolver computes a Risk Level from a tool's enforced sandbox policy. It is a monotonic max-merge over the tool's network, filesystem, and class permissions (specification Section 10.6). The Risk Level is an observational distillation; the policy is what the runtime enforces.
+
+| Level | Enforced capability (network / filesystem / class), per Section 10.6 |
+|---|---|
+| **L0** | No network, no filesystem, no added classes. Pure compute; no detected risk. |
+| **L3** | Scoped capability: network allowlist (non-wildcard) or strict mode; or file read; or a minor class allowance. |
+| **L4** | Unrestricted capability: network wildcard allowlist or open mode; or file write; or reflection/network class access. |
+| **L5** | Privileged host-control class (the specification's term is "escape class"): System / Runtime / Process access, or a file-write class. |
+
+The scale runs L0 to L5, but the sandbox calculator emits only L0, L3, L4, and L5. L1 and L2 are not gaps reserved for a future revision. They belong to a second calculator. The reference implementation reuses one `RiskLevel` enum across two independent models: this sandbox model, whose capability thresholds begin at L3 (any capability beyond pure compute is at least "moderate"), and a separate connection-risk model for external servers that does use L1 ("Safe") and L2 ("Low"). The second model is covered in the *External Tools* section.
+
+A per-call human-in-the-loop (HITL) gate (`humanInTheLoop = REQUIRED`) is **orthogonal to the Risk Level by specification** (Section 10.7). It does not lower the level, and it does not change the capability. It decides whether a specific call runs at all: deny-by-default, enforced at two points (an on-device dialog, and an MCP `elicitation/create` gate). Its AIVSS effect falls on Execution Autonomy, not on control surface. Crosswalk A states this precisely.
+
+## The crosswalk (enforced posture) ##
+
+### A. Enforced posture to External Tool Control Surface ###
+
+The amplification factor takes one of three values: 0.0, 0.5, or 1.0. Each Risk Level maps to exactly one value, using the Section 10.6 boundary between scoped (L3) and unrestricted (L4) capability. There is no range:
+
+| Enforced posture | External Tool Control Surface | Rule |
+|---|---|---|
+| L0 | **0.0** | No external surface. |
+| L3 | **0.5** | Scoped: non-wildcard allowlist or strict egress, or file read. |
+| L4 | **1.0** | Unrestricted: wildcard or open egress, or any file write. |
+| L5 | **1.0** | Privileged host control. |
+
+Any file write resolves to 1.0, because file write is L4 by Section 10.6. A non-wildcard allowlist with read-only access resolves to 0.5. The level fixes the value.
+
+A required HITL gate may justify lowering **Execution Autonomy**, since a human gates each call. It does **not** change the External Tool Control Surface: the tool's capability is the same whether or not a human approves a given call. The wording "may justify," rather than "lowers," is deliberate. A gate that suffers approval fatigue or auto-approval is weaker mitigation than one a human reviews attentively, so the reduction is a judgment, not an automatic discount. The reference implementation's one-band reduction is an external-path accounting convention, described in the *External Tools* section.
+
+### B. Enforced posture to CS, Impact, and DC ###
+
+Each mapping gives a single deterministic value per level, traceable to a published AIVSS rubric band. The values are proposed defaults for the public review; an implementation may calibrate within the cited band.
+
+**CS · Insecure Apps/Plugins.** Rubric bands: 0.1–0.3 sandboxed and verified; 0.4–0.6 sandboxed but broad; 0.7–1.0 unsandboxed. A per-tool sandbox the tool cannot widen past its declared policy gives:
+
+| Level | Value | Rubric band |
+|---|---|---|
+| L0 | **0.2** | 0.1–0.3 (enforced least privilege) |
+| L3 | **0.4** | 0.4–0.6 (sandboxed, scoped) |
+| L4 | **0.6** | 0.4–0.6 (sandboxed, broad) |
+| L5 | **0.9** | 0.7–1.0 (escape class) |
+
+**Impact (C / I / A), per the AIVSS project README, Section 6.** The values below are proposed deterministic ceilings for public review. The posture sets the ceiling; the actual value is at most the ceiling, refined downward by the sensitivity of the data the tool handles. Values use the Section 6 set (None 0.0, Low 0.22, Medium 0.55, High 0.85, Critical 1.0):
+
+| Level | C ceiling | I ceiling | A ceiling |
+|---|---|---|---|
+| L0 | 0.0 | 0.0 | 0.0 |
+| L3 | 0.55 | 0.22 | 0.22 |
+| L4 | 0.85 | 0.85 | 0.85 |
+| L5 | 0.85 | 1.0 | 0.85 |
+
+The C ceiling applies when the posture permits network egress; a read-only posture with no egress bounds C at None.
+
+**DC · Decision Criticality.** A reversible L0 tool contributes 0.0 to Operational Disruption. A file-write or host-control posture (L4–L5) is irreversible at host scope and raises it; an L5 tool anchors near 0.8.
+
+### Conformance requirements for the runtime ###
+
+The upper-bound property above holds only where the runtime enforces the posture faithfully. For the filesystem-derived values to be sound, a conformant runtime MUST **validate filesystem paths after resolving symbolic links**: a lexical check (`normalize()` plus a `startsWith(base)` prefix test) is not sufficient on its own, because a symbolic link under the base that targets a location outside it passes a lexical check yet resolves outside the base. The runtime MUST resolve links (for example with `toRealPath`) before the containment test, and MUST NOT follow links out of the base during directory walks.
+
+The egress side is a **scoring caveat, not a runtime defect**. By design, `allowlist` network mode trusts an explicit host list and may include internal-network hosts, with no per-IP or DNS-rebind guard; it is an explicit-trust mode. For scoring, an allowlist that includes private or internal hosts widens a tool's reach, so its egress-derived Confidentiality and control-surface contribution should be scored as broader accordingly.
+
+A runtime that does not meet the filesystem requirement does not provide the stated upper bound for filesystem-derived values.
+
+## External Tools: A Separate, Lower-Assurance Signal ##
+
+The mapping above is the enforced path, for locally-authored tools. A tool imported from an external, untrusted MCP server cannot be sandboxed by the client. The client can only read what the upstream declares, and watch it for change. This is a second risk model. It is declarative, not enforced. It maps to AIVSS at lower assurance.
+
+**Declared MCP annotations.** The reference implementation reads the available, catalogued MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`), plus a side-effect scope (`REMOTE_WRITE`, `REMOTE_ADMIN`) and a sends-user-data flag. These inform External Tool Control Surface and Impact, but as hints the upstream asserts, not as enforced capability. Two floor rules raise the level: an irreversible verb in the tool name (for example `delete_`, `drop_`, `purge_`), and `destructiveHint` without `idempotentHint`. The assurance gap is the whole point. An enforced posture is an upper bound the runtime guarantees; a declared annotation is an assertion the upstream can violate. AIVSS inputs from the enforced path carry materially higher confidence.
+
+**Change-detection ledger, to CS · Insecure Supply Chain.** In the live composition path, the implementation stores a SHA-256 of each tool's canonical content: name, description, and input schema. On re-check it returns `NEW`, `UNCHANGED`, or `MISMATCH`. A silent redefinition flips the tool to `AWAITING_REREVIEW`, so a rug-pull redefinition cannot ride in on a prior approval. This is detection, not prevention, and not cryptographic signing. It maps to CS · Insecure Supply Chain at a proposed **0.3**, the weak end of the 0.1–0.3 band, because it detects change after the fact rather than attesting provenance.
+
+**Limitations, stated plainly.** The ledger hashes the declared interface (name, description, and input schema), so a change behind that interface escapes it: a server can keep an identical name, description, and schema while changing its backend behavior. The hash is `UNCHANGED`, and the change is undetectable. This is intrinsic to content-hashing a remote black box from the client: behavior the client cannot observe cannot be hashed. Closing this gap is out of scope for a client-side ledger. It requires upstream provenance, or signed attestation of behavior, which is a separate control. That is the direction of MCP supply-chain proposals such as digest-pinned, signed tool descriptors.
+
+**HITL on the external path.** For a composed external tool, the reference implementation lowers the displayed composite level by one band: `max(L1, level - 1)`. This is a risk-accounting convention for the operator's view, floored at L1. In AIVSS terms it remains an Execution Autonomy adjustment, not a capability reduction.
+
+## A clean bridge through MCP ##
+
+MCP standardizes `ToolAnnotations`: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. An enforced posture can be projected onto these on publish. The path is portable:
+
+```
+enforced posture (L0–L5)  ->  MCP ToolAnnotations  ->  AIVSS (External Tool Control Surface + CS / DC / Impact)
+```
+
+A conformant implementation can act as a reference converter: enforced capability in, AIVSS tool-capability inputs out.
+
+## Worked example ##
+
+Two locally-authored tools behind the same LLM, expressed as AIVSS inputs from their enforced posture:
+
+```python
+# Tool 1: format_date  (enforced L0, pure compute, no I/O)
+posture_1 = {
+    "risk_level": "L0",                      # enforced sandbox level
+    "external_tool_control_surface": 0.0,    # amplification factor
+    "execution_autonomy": 0.5,               # autonomous, but no surface to act on
+    "impact": {"C": 0.0, "I": 0.0, "A": 0.0},
+    "cs": {"insecure_apps_plugins": 0.2},    # enforced least-privilege sandbox
+    "dc": {"operational_disruption": 0.0},
+}
+
+# Tool 2: run_shell  (enforced L5, System / Process access)
+posture_2 = {
+    "risk_level": "L5",                      # enforced sandbox level (escape class)
+    "external_tool_control_surface": 1.0,
+    "execution_autonomy": 0.5,               # a required HITL gate may justify lowering this; capability is unchanged
+    "impact": {"C": 0.85, "I": 1.0, "A": 0.85},
+    "cs": {"insecure_apps_plugins": 0.9},
+    "dc": {"operational_disruption": 0.8},
+}
+```
+
+The model and the prompt-injection exposure are identical. The enforced posture still separates a negligible blast radius from an escape-class one, before any AIVSS sub-category is scored by hand.
+
+## Scope boundary ##
+
+This crosswalk is single-tool by design. It does not estimate the agent-system amplification factors: Persistent State Retention (Memory), Multi-Agent Interactions, and Self-Modification. Those live above an individual tool. The crosswalk supplies the tool-capability inputs (External Tool Control Surface, and the CS, DC, and Impact contributions of one tool). Higher-level tooling scores the rest.
+
+## Reference implementation ##
+
+Spring AI Playground, an Apache-2.0 project incubating in the Spring AI Community, provides a working reference implementation. It demonstrates the posture resolver, the HITL gate, the external risk model, and the ledger; filesystem upper-bound conformance depends on the runtime requirements in *Conformance requirements for the runtime*. The AIVSS mapping in this document is a separate contribution: a proposed calibration offered for the public review, not a normative part of that project.
+
+* A normative on-disk Safe Tool Specification (RFC 2119; with spec, resolver, and runtime conformance classes). Its resolver computes the L0–L5 posture, and a sandbox applies that posture per tool, subject to the runtime obligations for a faithful upper bound listed in *Conformance requirements for the runtime*.
+* A per-call human-in-the-loop gate (`humanInTheLoop = REQUIRED`), enforced at an on-device dialog and an MCP elicitation checkpoint, deny-by-default.
+* For external tools, a separate declarative risk model (it reads MCP annotations plus trust, auth, and documentation signals) and a SHA-256 change-detection ledger that flags silently-redefined upstream tools for re-review.
+
+Links:
+
+* Project: <https://github.com/spring-ai-community/spring-ai-playground>
+* Normative spec (Safe Tool Specification): <https://spring-ai-community.github.io/spring-ai-playground/safe-tool-specification/>
+* L0–L5 resolution algorithm: [Safe Tool Specification Section 10.6, Risk Level](https://spring-ai-community.github.io/spring-ai-playground/safe-tool-specification/#106-risk-level)
+
+## Conclusion ##
+
+Agentic risk turns on what a tool can do. When that capability is enforced by a sandbox and distilled from an inspectable, normative specification, it stops being a reviewer's estimate and becomes a reproducible input. The specification is normative, the enforcement obligations are explicit, and the AIVSS values mapped here are proposed for calibration in the public review, not asserted as final, and each is traceable to a published rubric band. A separate, clearly-labeled declarative signal extends the same mapping to external tools at lower assurance, with the limits of both paths stated rather than hidden. We offer this crosswalk, and a working reference implementation, for the v1.0 public review.
+
+*Feedback welcome, in particular on two points. First, whether the External Tool Control Surface values match the intended v1.0 semantics. Second, whether a tool-capability input adapter (enforced posture, or MCP `ToolAnnotations`, to AIVSS inputs) would be a useful companion to the calculator.*


### PR DESCRIPTION
## Description

Adds `MCP-Tool-Capability-AIVSS.md` (root-level, `layout: col-sidebar`, alongside `Financial-AIVSS.md` and `aiuc-aivss-crosswalk.md`): a crosswalk mapping a tool's enforced sandbox capability posture (L0–L5) to existing AIVSS inputs: the External Tool Control Surface amplification factor and the CS / Impact / DC metrics (AIVSS README, Sections 4 and 6).

It is an input provider, not a competing scale; the values are proposed defaults for v1.0 calibration, each traceable to a rubric band. A separate, lower-assurance section covers external/untrusted MCP tools, and limitations are stated rather than hidden. Reference implementation: Spring AI Playground (Apache-2.0, Spring AI Community incubating), https://github.com/spring-ai-community/spring-ai-playground.

Asking for: feedback on whether the External Tool Control Surface values fit the intended v1.0 semantics.

## Type of Contribution
- [x] Framework improvement
- [ ] Documentation update
- [x] Research/Analysis
- [ ] Translation
- [ ] Other

## Checklist
- [x] Documentation is clear and concise
- [x] Changes are properly referenced
- [x] Spelling and grammar checked